### PR TITLE
Change - Update data types accepted by the systemd::unit class

### DIFF
--- a/manifests/unit.pp
+++ b/manifests/unit.pp
@@ -16,7 +16,7 @@ define systemd::unit (
         Optional[Boolean]                               $enable=true,
         Optional[String]                                $content=undef,
         Optional[String]                                $source=undef,
-        Optional[Variant[String[1], Array[String[1]]]]  $restart_events=undef,
+        Optional[Variant[String[1], Array[String[1]], Array[Type[Resource]], Type[Resource]]] $restart_events=undef,
         Optional[String[1]]                             $path=undef,
         Optional[String[1]]                             $extends=undef,
     ) {


### PR DESCRIPTION
Updated the restart_events parameter to accept puppet resource references along with string values.  Without this change in place any manifest that attempts to called systemd::unit using a resource reference value will fail.

For example, the following error is shown when running unit tests in the jetbrains module.

```
Puppet::Error:
        Expected parameter 'restart_events' of 'Systemd::Unit[teamcity-server-9.0.1.service]' to have type Optional[Variant[String[1, default], Array[String[1, default]]]], got Type[File['/opt/jetbrains/teamcity/etc/rc']]
```